### PR TITLE
[DevUtilities] Add ApplySingleItemDocBlockStyleRector

### DIFF
--- a/src/Common/src/Actions/UnauthorizedActionOverride.php
+++ b/src/Common/src/Actions/UnauthorizedActionOverride.php
@@ -12,9 +12,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS)]
 class UnauthorizedActionOverride
 {
-    /**
-     * @param  mixed  $value  The value to return when authorization fails
-     */
+    /** @param  mixed  $value  The value to return when authorization fails */
     public function __construct(
         public readonly mixed $value = null
     ) {}

--- a/src/DevUtilities/src/Rector/Rector.php
+++ b/src/DevUtilities/src/Rector/Rector.php
@@ -7,6 +7,7 @@
 
 namespace PHPGenesis\DevUtilities\Rector;
 
+use PHPGenesis\DevUtilities\Rector\Rules\ApplySingleItemDocBlockStyleRector;
 use PHPGenesis\DevUtilities\Rector\Rules\ReplaceSingleQuotesWithDoubleRector;
 use Rector\CodeQuality\Rector\Assign\CombinedAssignRector;
 use Rector\CodeQuality\Rector\BooleanAnd\RemoveUselessIsObjectCheckRector;
@@ -234,6 +235,7 @@ class Rector
         $allRules = array_merge([
             AddVoidReturnTypeWhereNoReturnRector::class,
             ReplaceSingleQuotesWithDoubleRector::class,
+            ApplySingleItemDocBlockStyleRector::class,
             CombinedAssignRector::class,
             RemoveUselessIsObjectCheckRector::class,
             SimplifyEmptyArrayCheckRector::class,

--- a/src/DevUtilities/src/Rector/Rules/ApplySingleItemDocBlockStyleRector.php
+++ b/src/DevUtilities/src/Rector/Rules/ApplySingleItemDocBlockStyleRector.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * Copyright (c) 2024-2025. Encore Digital Group.
+ * All Rights Reserved.
+ */
+
+namespace PHPGenesis\DevUtilities\Rector\Rules;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassConst;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Property;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class ApplySingleItemDocBlockStyleRector extends AbstractRector
+{
+    public function getNodeTypes(): array
+    {
+        return [
+            Class_::class,
+            ClassMethod::class,
+            Property::class,
+            ClassConst::class,
+        ];
+    }
+
+    /** @param Class_|ClassMethod|Property|ClassConst $node */
+    public function refactor(Node $node): ?Node
+    {
+        $docComment = $node->getDocComment();
+
+        if (!$docComment instanceof Doc) {
+            return null;
+        }
+
+        $originalText = $docComment->getText();
+        $collapsedText = $this->collapseDocBlock($originalText);
+
+        if ($collapsedText === null || $collapsedText === $originalText) {
+            return null;
+        }
+
+        // Create new doc comment with collapsed text
+        $node->setDocComment(new Doc($collapsedText));
+
+        return $node;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition("Collapse multi-line docblocks into single line format", [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    /**
+     * @var string
+     */
+    private string $name;
+
+    /**
+     * @return void
+     */
+    public function someMethod(): void
+    {
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    /** @var string */
+    private string $name;
+
+    /** @return void */
+    public function someMethod(): void
+    {
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    private function collapseDocBlock(string $docBlock): ?string
+    {
+        // Remove the opening /** and closing */
+        $lines = explode("\n", $docBlock);
+
+        if (count($lines) <= 1) {
+            return null; // Already single line or invalid
+        }
+
+        $contentLines = [];
+
+        foreach ($lines as $line) {
+            $trimmedLine = trim($line);
+            // Skip opening /** and closing */
+            if ($trimmedLine === "/**") {
+                continue;
+            }
+            if ($trimmedLine === "*/") {
+                continue;
+            }
+
+            // Remove leading * and whitespace
+            $trimmedLine = preg_replace('/^\*\s?/', "", $trimmedLine);
+
+            if ($trimmedLine !== "") {
+                $contentLines[] = $trimmedLine;
+            }
+        }
+
+        // Don't collapse if there are multiple content lines (e.g., description + tags)
+        // or if there are no content lines
+        if (count($contentLines) !== 1) {
+            return null;
+        }
+
+        // Create single-line docblock
+        return "/** " . $contentLines[0] . " */";
+    }
+}

--- a/src/DevUtilities/src/Rector/Rules/ReplaceSingleQuotesWithDoubleRector.php
+++ b/src/DevUtilities/src/Rector/Rules/ReplaceSingleQuotesWithDoubleRector.php
@@ -22,9 +22,7 @@ final class ReplaceSingleQuotesWithDoubleRector extends AbstractRector
         return [String_::class];
     }
 
-    /**
-     * @param  String_  $node
-     */
+    /** @param String_ $node */
     public function refactor(Node $node): ?Node
     {
         if ($node->getAttribute("kind") === String_::KIND_SINGLE_QUOTED) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new code style rule that automatically reformats multi-line docblocks into single-line format when containing a single line of content.

* **Chores**
  * Updated documentation formatting across existing code style rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->